### PR TITLE
Update null/undefined handling in `docData`, `objectVal`, `listVal`

### DIFF
--- a/database/list/index.ts
+++ b/database/list/index.ts
@@ -65,9 +65,19 @@ export function list(
  * @param query object ref or query
  * @param keyField map the object key to a specific field
  */
-export function listVal<T>(query: Query, keyField?: string): Observable<T[]> {
+export function listVal<T>(
+    query: Query,
+    keyField?: string,
+): Observable<T[] | null> {
   return list(query).pipe(
-      map((arr) => arr.map((change) => changeToData(change, keyField) as T)),
+      map((arr) => {
+        // in case the list doesn't exist, match the RTDB SDK's default behavior
+        if (arr.length === 0) {
+          return null;
+        }
+
+        return arr.map((change) => changeToData(change, keyField) as T);
+      }),
   );
 }
 

--- a/database/list/index.ts
+++ b/database/list/index.ts
@@ -50,6 +50,11 @@ export function list(
   const eventsList = validateEventsArray(events);
   return fromOnce(query).pipe(
       switchMap((change) => {
+      // in case the list doesn't exist, match the RTDB SDK's default behavior
+        if (!change.snapshot.exists()) {
+          return of(change.snapshot.val());
+        }
+
         const childEvent$ = [of(change)];
         for (const event of eventsList) {
           childEvent$.push(fromRef(query, event));
@@ -71,12 +76,7 @@ export function listVal<T>(
 ): Observable<T[] | null> {
   return list(query).pipe(
       map((arr) => {
-        // in case the list doesn't exist, match the RTDB SDK's default behavior
-        if (arr.length === 0) {
-          return null;
-        }
-
-        return arr.map((change) => changeToData(change, keyField) as T);
+        return arr?.map((change) => changeToData(change, keyField) as T);
       }),
   );
 }

--- a/database/list/index.ts
+++ b/database/list/index.ts
@@ -50,7 +50,7 @@ export function list(
   const eventsList = validateEventsArray(events);
   return fromOnce(query).pipe(
       switchMap((change) => {
-      // in case the list doesn't exist, match the RTDB SDK's default behavior
+        // in case the list doesn't exist, match the RTDB SDK's default behavior
         if (!change.snapshot.exists()) {
           return of(change.snapshot.val());
         }
@@ -76,7 +76,12 @@ export function listVal<T>(
 ): Observable<T[] | null> {
   return list(query).pipe(
       map((arr) => {
-        return arr?.map((change) => changeToData(change, keyField) as T);
+        // result can be null if query returns no data
+        if (arr === null) {
+          return arr;
+        }
+
+        return arr.map((change) => changeToData(change, keyField) as T);
       }),
   );
 }

--- a/database/object/index.ts
+++ b/database/object/index.ts
@@ -44,8 +44,13 @@ export function objectVal<T>(query: Query, keyField?: string): Observable<T> {
 export function changeToData(change: QueryChange, keyField?: string): {} {
   const val = change.snapshot.val();
 
+  // match the behavior of the JS SDK when the snapshot doesn't exist
+  if (change.snapshot.exists() === false) {
+    return val;
+  }
+
   // val can be a primitive type
-  if (typeof val !== 'object' || val === null) {
+  if (typeof val !== 'object') {
     return val;
   }
 

--- a/database/object/index.ts
+++ b/database/object/index.ts
@@ -45,7 +45,7 @@ export function changeToData(change: QueryChange, keyField?: string): {} {
   const val = change.snapshot.val();
 
   // match the behavior of the JS SDK when the snapshot doesn't exist
-  if (change.snapshot.exists() === false) {
+  if (!change.snapshot.exists()) {
     return val;
   }
 

--- a/database/object/index.ts
+++ b/database/object/index.ts
@@ -45,7 +45,7 @@ export function changeToData(change: QueryChange, keyField?: string): {} {
   const val = change.snapshot.val();
 
   // val can be a primitive type
-  if (typeof val !== 'object') {
+  if (typeof val !== 'object' || val === null) {
     return val;
   }
 

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -38,7 +38,15 @@ export function docData<T>(
   return doc(ref).pipe(map((snap) => snapToData(snap, idField) as T));
 }
 
-export function snapToData(snapshot: DocumentSnapshot, idField?: string): {} {
+export function snapToData(
+    snapshot: DocumentSnapshot,
+    idField?: string,
+): {} | undefined {
+  // match the behavior of the JS SDK when the snapshot doesn't exist
+  if (!snapshot.exists) {
+    return snapshot.data();
+  }
+
   return {
     ...snapshot.data(),
     ...(idField ? {[idField]: snapshot.id} : null),

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -674,14 +674,27 @@ describe('RxFire Database', () => {
       });
     });
 
-    it('objectVal should behave the same as snap.val() when an object doesn\'t exist', (done: MochaDone) => {
+    it('objectVal should behave the same as snap.val() when an object doesn\'t exist', (done) => {
       const nonExistentRef = ref('nonexistent');
       nonExistentRef.set(null);
       const obs = objectVal(nonExistentRef);
 
       nonExistentRef.on('value', (snap) => {
         obs.subscribe((val) => {
-          expect(val).to.deep.equal(snap.val());
+          expect(val).toEqual(snap.val());
+          done();
+        });
+      });
+    });
+
+    it('listVal should behave the same as snap.val() when a list doesn\'t exist', (done) => {
+      const nonExistentRef = ref('nonexistent');
+      nonExistentRef.set(null);
+      const obs = listVal(nonExistentRef);
+
+      nonExistentRef.on('value', (snap) => {
+        obs.subscribe((val) => {
+          expect(val).toEqual(snap.val());
           done();
         });
       });

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -545,18 +545,17 @@ describe('RxFire Database', () => {
         });
       });
 
-      /**
-       * This test checks that empty sets are processed.
-       */
-      it('should handle empty sets', (done) => {
-        const aref = ref(rando());
-        aref.set({});
-        list(aref)
-            .pipe(take(1))
-            .subscribe((data) => {
-              expect(data.length).toBe(0);
-            })
-            .add(done);
+      it('matches the output of the JS SDK when a set doesn\'t exist', (done) => {
+        const nonExistentRef = ref(rando());
+        nonExistentRef.set(null);
+        const obs = list(nonExistentRef);
+
+        nonExistentRef.on('value', (snap) => {
+          obs.subscribe((data) => {
+            expect(data).toEqual(snap.val());
+            done();
+          });
+        });
       });
 
       /**
@@ -587,7 +586,7 @@ describe('RxFire Database', () => {
               }
               // on the second round, we should have filtered out everything
               if (count === 2) {
-                expect(Object.keys(data).length).toBe(0);
+                expect(data).toBeNull();
               }
             })
             .add(done);
@@ -675,7 +674,7 @@ describe('RxFire Database', () => {
     });
 
     it('objectVal should behave the same as snap.val() when an object doesn\'t exist', (done) => {
-      const nonExistentRef = ref('nonexistent');
+      const nonExistentRef = ref(rando());
       nonExistentRef.set(null);
       const obs = objectVal(nonExistentRef);
 
@@ -688,7 +687,7 @@ describe('RxFire Database', () => {
     });
 
     it('listVal should behave the same as snap.val() when a list doesn\'t exist', (done) => {
-      const nonExistentRef = ref('nonexistent');
+      const nonExistentRef = ref(rando());
       nonExistentRef.set(null);
       const obs = listVal(nonExistentRef);
 

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -673,5 +673,18 @@ describe('RxFire Database', () => {
         done();
       });
     });
+
+    it('objectVal should behave the same as snap.val() when an object doesn\'t exist', (done: MochaDone) => {
+      const nonExistentRef = ref('nonexistent');
+      nonExistentRef.set(null);
+      const obs = objectVal(nonExistentRef);
+
+      nonExistentRef.on('value', (snap) => {
+        obs.subscribe((val) => {
+          expect(val).to.deep.equal(snap.val());
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -351,7 +351,7 @@ describe('RxFire Firestore', () => {
 
       nonExistentDoc.onSnapshot((snap) => {
         unwrapped.subscribe((val) => {
-          expect(val).to.eql(snap.data());
+          expect(val).toEqual(snap.data());
           done();
         });
       });

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -346,7 +346,7 @@ describe('RxFire Firestore', () => {
       const {colRef} = seedTest(firestore);
 
       const nonExistentDoc: firestore.DocumentReference = colRef.doc(
-          'I-AM-A-DOC-THAT-DOES-NOT-EXIST',
+          createId(),
       );
 
       const unwrapped = docData(nonExistentDoc);
@@ -360,9 +360,7 @@ describe('RxFire Firestore', () => {
     });
 
     it('collectionData matches the result of querySnapShot.docs when the collection doesn\'t exist', (done) => {
-      const nonExistentCollection = firestore.collection(
-          'I-AM-A-COLLECTION-THAT-DOES-NOT-EXIST',
-      );
+      const nonExistentCollection = firestore.collection(createId());
 
       const unwrapped = collectionData(nonExistentCollection);
 

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -342,7 +342,7 @@ describe('RxFire Firestore', () => {
       });
     });
 
-    it('docData matches the result of docSnapShot.data() when the document doesn\'t exist', (done: MochaDone) => {
+    it('docData matches the result of docSnapShot.data() when the document doesn\'t exist', (done) => {
       const {colRef} = seedTest(firestore);
 
       const nonExistentDoc: firestore.DocumentReference = colRef.doc('jeff');
@@ -352,6 +352,19 @@ describe('RxFire Firestore', () => {
       nonExistentDoc.onSnapshot((snap) => {
         unwrapped.subscribe((val) => {
           expect(val).toEqual(snap.data());
+          done();
+        });
+      });
+    });
+
+    it('collectionData matches the result of querySnapShot.data() when the document doesn\'t exist', (done) => {
+      const nonExistentCollection = firestore.collection('I-DO-NOT-EXIST');
+
+      const unwrapped = collectionData(nonExistentCollection);
+
+      nonExistentCollection.onSnapshot((snap) => {
+        unwrapped.subscribe((val) => {
+          expect(val).toEqual(snap.docs);
           done();
         });
       });

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -345,7 +345,9 @@ describe('RxFire Firestore', () => {
     it('docData matches the result of docSnapShot.data() when the document doesn\'t exist', (done) => {
       const {colRef} = seedTest(firestore);
 
-      const nonExistentDoc: firestore.DocumentReference = colRef.doc('jeff');
+      const nonExistentDoc: firestore.DocumentReference = colRef.doc(
+          'I-AM-A-DOC-THAT-DOES-NOT-EXIST',
+      );
 
       const unwrapped = docData(nonExistentDoc);
 
@@ -357,8 +359,10 @@ describe('RxFire Firestore', () => {
       });
     });
 
-    it('collectionData matches the result of querySnapShot.data() when the document doesn\'t exist', (done) => {
-      const nonExistentCollection = firestore.collection('I-DO-NOT-EXIST');
+    it('collectionData matches the result of querySnapShot.docs when the collection doesn\'t exist', (done) => {
+      const nonExistentCollection = firestore.collection(
+          'I-AM-A-COLLECTION-THAT-DOES-NOT-EXIST',
+      );
 
       const unwrapped = collectionData(nonExistentCollection);
 

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -341,5 +341,20 @@ describe('RxFire Firestore', () => {
         done();
       });
     });
+
+    it('docData matches the result of docSnapShot.data() when the document doesn\'t exist', (done: MochaDone) => {
+      const {colRef} = seedTest(firestore);
+
+      const nonExistentDoc: firestore.DocumentReference = colRef.doc('jeff');
+
+      const unwrapped = docData(nonExistentDoc);
+
+      nonExistentDoc.onSnapshot((snap) => {
+        unwrapped.subscribe((val) => {
+          expect(val).to.eql(snap.data());
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Updated rxfire's convenience observables to match the behavior of the JS SDK when values aren't found.

This revives https://github.com/firebase/firebase-js-sdk/issues/2561 and https://github.com/firebase/firebase-js-sdk/pull/2587

TODO:

- [x] fix & test `docData`
- [x] fix & test `objectVal`
- [x] fix & test `listVal`

### Context

When a query at a non-existent path is issued in rxFire's convenience functions `docData`, `objectVal`, and `listVal`, the returned value is different from what the plain JS SDK returns in `snap.data()` and `snap.val()`. `collectionData` works as expected

| method | expected output | actual output |
| --- | --- | --- |
| `docData` | `undefined`  | `{}` |
| `collectionData` | `[]`|`[]` |
| `objectVal` |`null` |`{}` |
| `listVal` | `null`|`[]` |

### [REQUIRED] Describe your environment

  * Firebase SDK version: rxfire 3.9.8
  * Firebase Product: database, firestore

### [REQUIRED] Describe the problem

#### Relevant Code:

https://stackblitz.com/fork/rxjs-1rtgsw