### PR TITLE
V5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
         id: node_modules_cache
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-14-8-node_modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-14-8-7-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-14-8-node_modules-
+            ${{ runner.os }}-14-8-7-node_modules-
             ${{ runner.os }}-14-node_modules-
       - name: Yarn offline cache
         if: steps.node_modules_cache.outputs.cache-hit != 'true'
@@ -58,10 +58,11 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: ["10", "12", "14"]
-        firebase: ["7", "8"]
+        node: ["12", "14", "16"]
+        firebase: ["8"]
+        rxjs: ["6", "7"]
       fail-fast: false
-    name: Test Firebase v${{ matrix.firebase }} on Node.js ${{ matrix.node }}
+    name: Test firebase@${{ matrix.firebase }} rxjs@${{ matrix.rxjs }} on Node.js ${{ matrix.node }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -75,9 +76,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-${{ matrix.node }}-${{ matrix.firebase }}-node_modules-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node }}-${{ matrix.firebase }}-${{ matrix.rxjs }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.node }}-${{ matrix.firebase }}-node_modules-
+            ${{ runner.os }}-${{ matrix.node }}-${{ matrix.firebase }}-${{ matrix.rxjs }}-node_modules-
             ${{ runner.os }}-${{ matrix.node }}-node_modules-
       - name: Yarn offline cache
         if: steps.node_modules_cache.outputs.cache-hit != 'true'
@@ -91,7 +92,7 @@ jobs:
         run: |
           yarn config set yarn-offline-mirror ~/.npm-packages-offline-cache
           yarn install --frozen-lockfile --prefer-offline
-          yarn add firebase@^${{ matrix.firebase }}.0 --prefer-offline
+          yarn add --dev firebase@${{ matrix.firebase }} rxjs@${{ matrix.rxjs }} --prefer-offline
       - name: Firebase emulator cache
         uses: actions/cache@v2
         with:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.ems.js",
+    "./auth": "./dist/auth/index.esm.js",
+    "./database": "./dist/database/index.esm.js",
+    "./firestore": "./dist/firestore/index.esm.js",
+    "./functions": "./dist/functions/index.esm.js",
+    "./storage": "./dist/storage/index.esm.js"
+  },
   "sideEffects": false,
   "keywords": [
     "authentication",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfire",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "private": true,
   "description": "Firebase JavaScript library RxJS",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
@@ -45,11 +45,11 @@
     "test": "jest"
   },
   "dependencies": {
-    "tslib": "^1.11.1"
+    "tslib": "^2.2.0"
   },
   "peerDependencies": {
     "firebase": "^8.0.0",
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -71,8 +71,8 @@
     "rollup": "^2.33.2",
     "rollup-plugin-generate-package-json": "^3.2.0",
     "rollup-plugin-uglify": "^6.0.4",
-    "rxjs": "^6.0.0",
-    "typescript": "^4.0.5"
+    "rxjs": "^7.0.0",
+    "typescript": "^4.2.4"
   },
   "files": [
     "dist/**/*",

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -470,14 +470,25 @@ describe('RxFire Database', () => {
        */
       it('should handle multiple subscriptions (hot)', (done) => {
         const {snapChanges, ref} = prepareList();
-        const sub = snapChanges.subscribe(() => {}).add(done);
+        let firstFired = false;
         snapChanges
             .pipe(take(1))
-            .subscribe((actions) => {
-              const data = actions.map((a) => a.snapshot.val());
-              expect(data).toEqual(items);
-            })
-            .add(sub);
+            .subscribe(actions => {
+                firstFired = true;
+                const data = actions.map((a) => a.snapshot.val());
+                console.log('first', data);
+                expect(data).toEqual(items);
+              }
+            );
+        snapChanges
+            .pipe(take(1))
+            .subscribe(actions => {
+                const data = actions.map((a) => a.snapshot.val());
+                expect(data).toEqual(items);
+                expect(firstFired).toBeTruthy();
+                done();
+              }
+            );
         ref.set(itemsObj);
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,12 +4920,12 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
-rxjs@^6.0.0:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+rxjs@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.0.0.tgz#c55d67c52aee8804d32ab60965e335bd41e2dc2d"
+  integrity sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==
   dependencies:
-    tslib "^1.9.0"
+    tslib "~2.1.0"
 
 safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
@@ -5436,10 +5436,20 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.11.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.19.1"
@@ -5506,10 +5516,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.5:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 uglify-js@^3.4.9:
   version "3.12.4"


### PR DESCRIPTION
* Bump to v5 to allow our storage / undefined breaks
* Allow RXJS 7, we still need to allow / test against 6 since Angular won't be upgrading the cycle
* Bump typscript and tslib
* Modernize the package with exports
* Add matrix for rxjs 6 and Node 16, drop firebase 7 and Node 10
* How `add` works in RXJS v7 changed, had to rewrite a test a bit to account for that