### PR TITLE
Playing around with generics and options

### DIFF
--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -34,15 +34,15 @@ export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<Docum
  */
 export function docData<T=DocumentData>(
     ref: DocumentReference<T>,
-    idField?: string,
+    idField?: keyof T,
 ): Observable<T> {
   return doc(ref).pipe(map(snap => snapToData(snap, idField) as T));
 }
 
 export function snapToData<T=DocumentData>(
     snapshot: DocumentSnapshot<T>,
-    idField?: string,
-): {} | undefined {
+    idField?: keyof T,
+): T | undefined {
   // match the behavior of the JS SDK when the snapshot doesn't exist
   if (!snapshot.exists) {
     return snapshot.data();
@@ -50,5 +50,5 @@ export function snapToData<T=DocumentData>(
   return {
     ...snapshot.data(),
     ...(idField ? { [idField]: snapshot.id } : null)
-  };
+  } as T;
 }


### PR DESCRIPTION
In playing around with the ergonomics of the current API and looking at our feature requests, I thought it would be a good pattern to break our second argument into an options object. Here's a first pass on what it might look like.

`collectionChanges(ref)` (default all events, `includeMetadata` true)
`collectionChanges(ref, { events: ['added'] })`
`collectionChanges(ref, { events: ['added'], snapshotListenOptions: { includeMetadata: false } })`

Also I've typed the `idField` option a little better, given our recent generics work.

`collectionData(ref) => Observable<DocumentData[]>`
`collectionData(ref, { idField: 'id' }) => Observable<DocumentData[]>`
`collectionData<Foo>(ref, { idField: 'id' }) => Observable<Foo[]>` with typescript erroring if `Foo` doesn't contain an `id: string` field.

I don't think I could force it to be `DocumentData & { id: string }` in the case that they don't explicitly pass a generic, unless we hurt the DevExp with something like `collectionData<Foo, 'id'>(ref, { idField: 'id' })`, which I'd rather not do. This would also forbid us from being flexible with options and adding something like `collectionData<Foo>(ref, { idField: 'id', refField: 'ref' })` which has been requested.

WDYTT? If you're both amenable, I'll draft it up for the other functions too.