### PR TITLE
Add snapshotOptions

### DIFF
--- a/firestore/collection/index.ts
+++ b/firestore/collection/index.ts
@@ -40,6 +40,7 @@ type DocumentChange<T> = firebase.firestore.DocumentChange<T>;
 type Query<T> = firebase.firestore.Query<T>;
 type QueryDocumentSnapshot<T> = firebase.firestore.QueryDocumentSnapshot<T>;
 type QuerySnapshot<T> = firebase.firestore.QuerySnapshot<T>;
+type SnapshotOptions = firebase.firestore.SnapshotOptions;
 
 const ALL_EVENTS: DocumentChangeType[] = ['added', 'modified', 'removed'];
 
@@ -284,10 +285,11 @@ export function auditTrail<T=DocumentData>(
 export function collectionData<T=DocumentData>(
     query: Query<T>,
     idField?: string,
+    snapshotOptions?: SnapshotOptions,
 ): Observable<T[]> {
   return collection(query).pipe(
     map(arr => {
-      return arr.map(snap => snapToData(snap, idField) as T);
+      return arr.map(snap => snapToData(snap, idField, snapshotOptions) as T);
     })
   );
 }

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -23,6 +23,7 @@ import { Observable } from 'rxjs';
 type DocumentData = firebase.firestore.DocumentData;
 type DocumentReference<T> = firebase.firestore.DocumentReference<T>;
 type DocumentSnapshot<T> = firebase.firestore.DocumentSnapshot<T>;
+type SnapshotOptions = firebase.firestore.SnapshotOptions;
 
 export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<DocumentSnapshot<T>> {
   return fromDocRef(ref, { includeMetadataChanges: true });
@@ -35,20 +36,22 @@ export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<Docum
 export function docData<T=DocumentData>(
     ref: DocumentReference<T>,
     idField?: string,
+    snapshotOptions?: SnapshotOptions,
 ): Observable<T> {
-  return doc(ref).pipe(map(snap => snapToData(snap, idField) as T));
+  return doc(ref).pipe(map(snap => snapToData(snap, idField, snapshotOptions) as T));
 }
 
 export function snapToData<T=DocumentData>(
     snapshot: DocumentSnapshot<T>,
     idField?: string,
+    snapshotOptions?: SnapshotOptions,
 ): {} | undefined {
   // match the behavior of the JS SDK when the snapshot doesn't exist
   if (!snapshot.exists) {
-    return snapshot.data();
+    return snapshot.data(snapshotOptions);
   }
   return {
-    ...snapshot.data(),
+    ...snapshot.data(snapshotOptions),
     ...(idField ? { [idField]: snapshot.id } : null)
   };
 }


### PR DESCRIPTION
Add an optional snapshotOptions parameter to docData and collectionData.

In the firebase javascript sdk you can do `doc.data({ serverTimestamps: "estimate" })`. There is currently no way to set this option object in rxfire when using docData and collectionData. This PR implements that.

https://firebase.google.com/docs/reference/js/firebase.firestore.SnapshotOptions