### PR TITLE
Fix TS source map conflict

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -86,7 +86,8 @@ export default Object.keys(packages)
         ],
         plugins: [
           ...plugins,
-          typescript(),
+          // TS sourceMaps conflict with Rollup sourceMaps
+          typescript({ sourceMap: false }),
           generatePackageJson({ outputFolder, baseContents }),
         ],
         external


### PR DESCRIPTION
The `tsconfig` has `sourceMap` set to `true`:

https://github.com/FirebaseExtended/rxfire/blob/c8eb81fb8cba1714a20986e9618bb9dad8ca0b56/tsconfig.json#L22

And so does `rollup.config.js`:

https://github.com/FirebaseExtended/rxfire/blob/c8eb81fb8cba1714a20986e9618bb9dad8ca0b56/rollup.config.js#L75-L86

Rollup seems to defer to TS, and as a result, the sourcemaps point to files that don't exist in the production package. For example, `firestore/index.esm.js.map` references `../../../firestore/fromRef.ts`.

Adding `sourceMap: false` to the TypeScript plugin in `rollup.config.js` should fix source maps for the prod build, while still allowing `sourceMap` to be set to true in tsconfig for dev work. I tested this locally and while it still seems to point to those files outside of the `dist` directory, it also includes all the code in the sourcemap, so it was useable in a web app that used rxfire as a dependency.