### PR TITLE
Allow entry-points to be tree-shaken by marking sideEffects false

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -3,5 +3,6 @@
   "browser": "../dist/auth/index.esm.js",
   "main": "../dist/auth/index.cjs.js",
   "module": "../dist/auth/index.esm.js",
-  "typings": "../dist/auth/index.d.ts"
+  "typings": "../dist/auth/index.d.ts",
+  "sideEffects": false
 }

--- a/database/package.json
+++ b/database/package.json
@@ -3,5 +3,6 @@
   "browser": "../dist/database/index.esm.js",
   "main": "../dist/database/index.cjs.js",
   "module": "../dist/database/index.esm.js",
-  "typings": "../dist/database/index.d.ts"
+  "typings": "../dist/database/index.d.ts",
+  "sideEffects": false
 }

--- a/firestore/package.json
+++ b/firestore/package.json
@@ -3,5 +3,6 @@
   "browser": "../dist/firestore/index.esm.js",
   "main": "../dist/firestore/index.cjs.js",
   "module": "../dist/firestore/index.esm.js",
-  "typings": "../dist/firestore/index.d.ts"
+  "typings": "../dist/firestore/index.d.ts",
+  "sideEffects": false
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,5 +3,6 @@
   "browser": "../dist/functions/index.esm.js",
   "main": "../dist/functions/index.cjs.js",
   "module": "../dist/functions/index.esm.js",
-  "typings": "../dist/functions/index.d.ts"
+  "typings": "../dist/functions/index.d.ts",
+  "sideEffects": false
 }

--- a/storage/package.json
+++ b/storage/package.json
@@ -3,5 +3,6 @@
   "browser": "../dist/storage/index.esm.js",
   "main": "../dist/storage/index.cjs.js",
   "module": "../dist/storage/index.esm.js",
-  "typings": "../dist/storage/index.d.ts"
+  "typings": "../dist/storage/index.d.ts",
+  "sideEffects": false
 }


### PR DESCRIPTION
The secondary entry-points aren't as tree-shakable as they could be, mark sideEffects false to maximize shakability.