### PR TITLE
Fix snapToData for Firebase v9 API

### DIFF
--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -41,7 +41,7 @@ export function snapToData<T=DocumentData>(
     idField?: string,
 ): {} | undefined {
   // match the behavior of the JS SDK when the snapshot doesn't exist
-  if (!snapshot.exists) {
+  if (!snapshot.exists()) {
     return snapshot.data();
   }
   return {


### PR DESCRIPTION
In Firebase SDK v9, `DocumentSnapshot.exists` was turned from a property to a method, which makes this if check always fail. As a result, using `docData` to get document data returns an empty object if the document doesn't exist. 

For v9, we need to always call the `exists` method.