### PR TITLE
[exp][feature request] getJSON for Remote Config

### DIFF
--- a/remote-config/index.ts
+++ b/remote-config/index.ts
@@ -1,10 +1,10 @@
-import { Observable } from 'rxjs';
+import {Observable} from 'rxjs';
 
 type RemoteConfig = import('firebase/remote-config').RemoteConfig;
 type RemoteConfigValue = import('firebase/remote-config').Value;
 
-import { 
-  ensureInitialized, 
+import {
+  ensureInitialized,
   getValue as baseGetValue,
   getString as baseGetString,
   getNumber as baseGetNumber,
@@ -22,8 +22,8 @@ interface ParameterSettings<T> {
   getter: (remoteConfig: RemoteConfig, key: string) => T;
 }
 
-function parameter$<T>({ remoteConfig, key, getter }: ParameterSettings<T>): Observable<T> {
-  return new Observable(subscriber => {
+function parameter$<T>({remoteConfig, key, getter}: ParameterSettings<T>): Observable<T> {
+  return new Observable((subscriber) => {
     ensureInitialized(remoteConfig).then(() => {
       // 'this' for the getter loses context in the next()
       // call, so it needs to be bound.
@@ -35,26 +35,31 @@ function parameter$<T>({ remoteConfig, key, getter }: ParameterSettings<T>): Obs
 
 export function getValue(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetValue;
-  return parameter$({ remoteConfig, key, getter });
+  return parameter$({remoteConfig, key, getter});
 }
 
 export function getString(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetString;
-  return parameter$<string>({ remoteConfig, key, getter });
+  return parameter$<string>({remoteConfig, key, getter});
 }
 
 export function getNumber(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetNumber;
-  return parameter$<number>({ remoteConfig, key, getter });
+  return parameter$<number>({remoteConfig, key, getter});
 }
 
 export function getBoolean(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetBoolean;
-  return parameter$<boolean>({ remoteConfig, key, getter });
+  return parameter$<boolean>({remoteConfig, key, getter});
 }
 
 export function getAll(remoteConfig: RemoteConfig) {
   const getter = baseGetAll;
   // No key is needed for getAll()
-  return parameter$<AllParameters>({ remoteConfig, key: '', getter });
+  return parameter$<AllParameters>({remoteConfig, key: '', getter});
+}
+
+export function getJSON<T>(remoteConfig: RemoteConfig, key: string) {
+  const getter = (remoteConfig: RemoteConfig, key: string) => JSON.parse(baseGetString(remoteConfig, key)) as T;
+  return parameter$<T>({remoteConfig, key, getter});
 }

--- a/remote-config/index.ts
+++ b/remote-config/index.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rxjs';
+import { Observable } from 'rxjs';
 
 type RemoteConfig = import('firebase/remote-config').RemoteConfig;
 type RemoteConfigValue = import('firebase/remote-config').Value;
@@ -22,8 +22,8 @@ interface ParameterSettings<T> {
   getter: (remoteConfig: RemoteConfig, key: string) => T;
 }
 
-function parameter$<T>({remoteConfig, key, getter}: ParameterSettings<T>): Observable<T> {
-  return new Observable((subscriber) => {
+function parameter$<T>({ remoteConfig, key, getter }: ParameterSettings<T>): Observable<T> {
+  return new Observable(subscriber => {
     ensureInitialized(remoteConfig).then(() => {
       // 'this' for the getter loses context in the next()
       // call, so it needs to be bound.
@@ -35,31 +35,31 @@ function parameter$<T>({remoteConfig, key, getter}: ParameterSettings<T>): Obser
 
 export function getValue(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetValue;
-  return parameter$({remoteConfig, key, getter});
+  return parameter$({ remoteConfig, key, getter });
 }
 
 export function getString(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetString;
-  return parameter$<string>({remoteConfig, key, getter});
+  return parameter$<string>({ remoteConfig, key, getter });
 }
 
 export function getNumber(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetNumber;
-  return parameter$<number>({remoteConfig, key, getter});
+  return parameter$<number>({ remoteConfig, key, getter });
 }
 
 export function getBoolean(remoteConfig: RemoteConfig, key: string) {
   const getter = baseGetBoolean;
-  return parameter$<boolean>({remoteConfig, key, getter});
+  return parameter$<boolean>({ remoteConfig, key, getter });
 }
 
 export function getAll(remoteConfig: RemoteConfig) {
   const getter = baseGetAll;
   // No key is needed for getAll()
-  return parameter$<AllParameters>({remoteConfig, key: '', getter});
+  return parameter$<AllParameters>({ remoteConfig, key: '', getter });
 }
 
 export function getJSON<T>(remoteConfig: RemoteConfig, key: string) {
   const getter = (remoteConfig: RemoteConfig, key: string) => JSON.parse(baseGetString(remoteConfig, key)) as T;
-  return parameter$<T>({remoteConfig, key, getter});
+  return parameter$<T>({ remoteConfig, key, getter });
 }


### PR DESCRIPTION
I was thinking, since Remote Config lets you add JSONs as a valid parameter, maybe rxfire could surface a getJSON function that will automatically parse the remote config parameter and can allow some generic type to be passed through for typescript users.