### PR TITLE
Don't splat classes if using data converters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+yarn.lock linguist-generated=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish (NPM)
-    needs: ['build']
+    needs: ['build', 'test']
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
     steps:
       - name: Setup node

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -44,12 +44,19 @@ export function snapToData<T=DocumentData>(
       idField?: string,
     }={}
 ): {} | undefined {
+  const data = snapshot.data() as any;
   // match the behavior of the JS SDK when the snapshot doesn't exist
   if (!snapshot.exists()) {
-    return snapshot.data();
+    return data;
   }
-  return {
-    ...snapshot.data(),
-    ...(options.idField ? { [options.idField]: snapshot.id } : null)
-  };
+  // If they used a data converter return it, throw if they used any of the option fields
+  if (data?.constructor?.name !== 'Object') {
+    if (options.idField) { throw `Set ${options.idField} in \`fromFirestore\`.`; }
+    return data;
+  } else {
+    return {
+      ...data,
+      ...(options.idField ? { [options.idField]: snapshot.id } : null)
+    };
+  }
 }

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -44,19 +44,13 @@ export function snapToData<T=DocumentData>(
       idField?: string,
     }={}
 ): {} | undefined {
+  // TODO clean up the typings
   const data = snapshot.data() as any;
   // match the behavior of the JS SDK when the snapshot doesn't exist
-  if (!snapshot.exists()) {
+  // it's possible with data converters too that the user didn't return an object
+  if (!snapshot.exists() || typeof data !== 'object' || data === null) {
     return data;
   }
-  // If they used a data converter return it, throw if they used any of the option fields
-  if (data?.constructor?.name !== 'Object') {
-    if (options.idField) { throw `Set ${options.idField} in \`fromFirestore\`.`; }
-    return data;
-  } else {
-    return {
-      ...data,
-      ...(options.idField ? { [options.idField]: snapshot.id } : null)
-    };
-  }
+  if (options.idField) { data[options.idField] = snapshot.id; }
+  return data;
 }

--- a/firestore/lite/document/index.ts
+++ b/firestore/lite/document/index.ts
@@ -44,20 +44,13 @@ export function snapToData<T=DocumentData>(
       idField?: string,
     }={}
 ): {} | undefined {
+  // TODO clean up the typings
   const data = snapshot.data() as any;
   // match the behavior of the JS SDK when the snapshot doesn't exist
   // it's possible with data converters too that the user didn't return an object
-  if (!snapshot.exists()) {
+  if (!snapshot.exists() || typeof data !== 'object' || data === null) {
     return data;
   }
-  // If they used a data converter return it, throw if they used any of the option fields
-  if (data?.constructor?.name !== 'Object') {
-    if (options.idField) { throw `Set ${options.idField} in \`fromFirestore\`.`; }
-    return data;
-  } else {
-    return {
-      ...data,
-      ...(options.idField ? { [options.idField]: snapshot.id } : null)
-    };
-  }
+  if (options.idField) { data[options.idField] = snapshot.id; }
+  return data;
 }

--- a/firestore/lite/document/index.ts
+++ b/firestore/lite/document/index.ts
@@ -44,12 +44,20 @@ export function snapToData<T=DocumentData>(
       idField?: string,
     }={}
 ): {} | undefined {
+  const data = snapshot.data() as any;
   // match the behavior of the JS SDK when the snapshot doesn't exist
+  // it's possible with data converters too that the user didn't return an object
   if (!snapshot.exists()) {
-    return snapshot.data();
+    return data;
   }
-  return {
-    ...snapshot.data(),
-    ...(options.idField ? { [options.idField]: snapshot.id } : null)
-  };
+  // If they used a data converter return it, throw if they used any of the option fields
+  if (data?.constructor?.name !== 'Object') {
+    if (options.idField) { throw `Set ${options.idField} in \`fromFirestore\`.`; }
+    return data;
+  } else {
+    return {
+      ...data,
+      ...(options.idField ? { [options.idField]: snapshot.id } : null)
+    };
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxfire",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "description": "Firebase JavaScript library RxJS",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
@@ -73,7 +73,7 @@
     "build:docs": "cp README.md ./dist/ && cp -r ./docs ./dist/",
     "dev": "rollup -c -w",
     "echo:chrome": "echo 'Open Chrome DevTools: \nchrome://inspect/#devices'",
-    "test": "FIREBASE_CLI_PREVIEWS=storageemulator firebase emulators:exec jest --project=rxfire-test-c497c",
+    "test": "FIREBASE_CLI_PREVIEWS=storageemulator firebase emulators:exec \"jest --detectOpenHandles\" --project=rxfire-test-c497c ",
     "test:debug": "yarn echo:chrome && FIREBASE_CLI_PREVIEWS=storageemulator firebase emulators:exec ./test-debug.sh --project=rxfire-test-c497c"
   },
   "dependencies": {

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -316,15 +316,19 @@ describe('RxFire Database', () => {
       it('should process a new child_added event', done => {
         const aref = builtRef(rando());
         const obs = list(aref, { events: [ListenEvent.added] });
-        obs
-          .pipe(skip(2), take(1))
-          .subscribe(changes => {
-            const data = changes.map(change => change.snapshot.val());
-            expect(data).toContainEqual({ name: 'anotha one' });
-          })
-          .add(done);
         set(aref, itemsObj).then(() => {
-          push(aref, { name: 'anotha one' });
+          let count = 0;
+          obs
+          .pipe(take(2))
+          .subscribe(changes => {
+            if (count++ === 0) {
+              push(aref, { name: 'anotha one' });
+            } else {
+              const data = changes.map(change => change.snapshot.val());
+              expect(data).toContainEqual({ name: 'anotha one' });
+              done();
+            }
+          });
         });
       });
 

--- a/test/firestore-lite.test.ts
+++ b/test/firestore-lite.test.ts
@@ -28,9 +28,9 @@ import {
   docData,
   collectionData,
 } from '../dist/firestore/lite';
-import {map, take, skip} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { default as TEST_PROJECT, firestoreEmulatorPort } from './config';
-import { doc as firestoreDoc, getDocs, collection as firestoreCollection, getDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, DocumentReference, connectFirestoreEmulator, doc, setDoc, collection as baseCollection } from 'firebase/firestore/lite';
+import { doc as firestoreDoc, getDocs, collection as firestoreCollection, getDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, DocumentReference, connectFirestoreEmulator, doc, setDoc, collection as baseCollection, QueryDocumentSnapshot } from 'firebase/firestore/lite';
 import { initializeApp, deleteApp, FirebaseApp } from 'firebase/app';
 
 const createId = (): string => Math.random().toString(36).substring(5);
@@ -100,6 +100,45 @@ describe('RxFire firestore/lite', () => {
           .pipe(map((docs) => docs.map((doc) => doc.data().name)))
           .subscribe((names) => {
             expect(names).toEqual(expectedNames);
+            done();
+          });
+    });
+  });
+
+
+  describe('collection w/converter', () => {
+    /**
+     * This is a simple test to see if the collection() method
+     * correctly emits snapshots.
+     *
+     * The test seeds two "people" into the collection. RxFire
+     * creats an observable with the `collection()` method and
+     * asserts that the two "people" are in the array.
+     */
+    it('should emit snapshots', async (done: jest.DoneCallback) => {
+      const {colRef, expectedNames} = await seedTest(firestore);
+
+      class Folk {
+        constructor(public name: string) { }
+        static fromFirestore(snap: QueryDocumentSnapshot) {
+          const name = snap.data().name;
+          if (name !== 'Shannon') {
+            return new Folk(`${snap.data().name}!`);
+          } else {
+            return undefined;
+          }
+        }
+        static toFirestore() {
+          return {};
+        }
+      }
+
+      collection(colRef.withConverter(Folk))
+          .subscribe(docs => {
+            const names = docs.map(doc => doc.data()?.name);
+            const classes = docs.map(doc => doc.data()?.constructor?.name);
+            expect(names).toEqual(['David!', undefined]);
+            expect(classes).toEqual(['Folk', undefined]);
             done();
           });
     });

--- a/test/firestore-lite.test.ts
+++ b/test/firestore-lite.test.ts
@@ -131,9 +131,10 @@ describe('RxFire firestore/lite', () => {
         static toFirestore() {
           return {};
         }
+        static collection = colRef.withConverter(Folk);
       }
 
-      collection(colRef.withConverter(Folk))
+      collection(Folk.collection)
           .subscribe(docs => {
             const names = docs.map(doc => doc.data()?.name);
             const classes = docs.map(doc => doc.data()?.constructor?.name);

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,10 +961,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@firebase/analytics-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.1.0.tgz#48f0c3b5557541dd0f1a463ffd1d807454ae1b8e"
-  integrity sha512-oaf1FEF7cKci5tO7f52dH63/ZwkBqbdSLLpgo6kyoYoYDuY+on4yAc1CIHh3sNj/L8T4Ni81IQvVs9lE/9oOpg==
+"@firebase/analytics-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.1.1.tgz#77a3e5d28f15df303c3836db4740a43955fcfcac"
+  integrity sha512-pMTrA8cxMXFRv7bwZEXXz0NCepnyH2Jay/32RZ7xAufij2VJhF5S1BtfCO0wuri3FB94rlM8SmSEbwxxHcAtVg==
   dependencies:
     "@firebase/analytics" "0.7.0"
     "@firebase/analytics-types" "0.7.0"
@@ -988,10 +988,10 @@
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
-"@firebase/app-check-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.1.0.tgz#5bf12e5cd82f76cac2eabe51345d1fed9664ed48"
-  integrity sha512-T1M2d1oroaHUa448fgx3BdfWg4WXP64yybIWxvmVBuh7YnyMuegJK1sS9zipKBKLkstcQK8vivXYh3+/AnbGFw==
+"@firebase/app-check-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.1.1.tgz#84c7ef29bb683fd3dea66a66f82b799474c904ee"
+  integrity sha512-XTV5Ns0Lpwn5GgXV5T0soOkoOGACaw9xiNvAXcISQYFBIse0k7fKo8V5J9VUS1ppzGpyTRCg0m9efz4CNrwPyQ==
   dependencies:
     "@firebase/app-check" "0.4.0"
     "@firebase/component" "0.5.6"
@@ -1014,10 +1014,10 @@
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.1.0.tgz#101070141198304a50ec546b7626870c7759166b"
-  integrity sha512-jnAeFM1ihY5klqg2dvdA4EOk7co8ffSHUj/efqaSwTrMkKTcG/WZKF9WAuXdl+5jEu1BhsGGHveWzGliTFH5Hg==
+"@firebase/app-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.1.1.tgz#47d5f5ac350f59ea4b721f17e01b1e46a1a3154a"
+  integrity sha512-AoUO7PnQlDPyMAvAE972kBhrwXRZRLGdHM8obyIeTzPNqIiEoULD4Rdq5TBB4UmV2HYAlYdrS+dk4nuWx67w6A==
   dependencies:
     "@firebase/app" "0.7.0"
     "@firebase/component" "0.5.6"
@@ -1040,12 +1040,12 @@
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
-"@firebase/auth-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.1.0.tgz#e5dc6bb6ac89ea21f85c4153eb1cf8a7d69deaa8"
-  integrity sha512-OfAt3c5ham07xvmYyJp02v8mUa+HaSEwilvgD2M1JaWqLAtqH66bdBhLBE9N0pq8xtRdXZIF1vSd20a0ulQfQg==
+"@firebase/auth-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.1.1.tgz#9baf7b50395ea29a8c3bd20d1c1a3d3cf9004534"
+  integrity sha512-wEGEV+SluDt/SRyLJRG+s32EDHsyahlkp7kXTcRLUs5KGHmK0T0wNrWxdN5eeR4wR/tlrasPNveUeQDyoJVQzw==
   dependencies:
-    "@firebase/auth" "0.17.0"
+    "@firebase/auth" "0.17.1"
     "@firebase/auth-types" "0.11.0"
     "@firebase/component" "0.5.6"
     "@firebase/util" "1.3.0"
@@ -1063,10 +1063,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.11.0.tgz#b9c73c60ca07945b3bbd7a097633e5f78fa9e886"
   integrity sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==
 
-"@firebase/auth@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.17.0.tgz#e1395779293e1869fabefd07e078242c773b5fcb"
-  integrity sha512-4zOGTLGzMjBX96KEyBNYpjOD87c2efCZvUjaJ53QslleW9Xp8kSsSHLRhr8hOkcRXO17CmBKSRx/LnG2vTZWQQ==
+"@firebase/auth@0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.17.1.tgz#4c3dd24ca5a9c47c5e97a9fd1bd4129c46154764"
+  integrity sha512-+YQM0svb10Q1LwoTj+/unrdY/F/C89bgsjlanY14k2124fiOYVZv0M19t5i7nZx8VnsrgzkFaDfKahdcDxjdpA==
   dependencies:
     "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
@@ -1115,13 +1115,13 @@
     faye-websocket "0.11.3"
     tslib "^2.1.0"
 
-"@firebase/firestore-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.1.0.tgz#9faa1c10a76d67f812dd48469693e8f6bafca3ab"
-  integrity sha512-25r1jGpnnx7vXSPVLmHNkuz+EGpZDU5Luro5/MFCMmoV4a+Rmg2n9FRlxRyPn4XOCkc5nrBpT6ESAKAPSNHcpw==
+"@firebase/firestore-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.1.1.tgz#a990cd4b0aef5e0a18972de71d18c35065099f19"
+  integrity sha512-Ag95WVTSh5Q+GK3egd9HBvXerO/lrRulTO67ryYp4EPyoI/ZmnIoMhYgnOXvb1jCH0Ae01XoSxgU2M2SRvph/Q==
   dependencies:
     "@firebase/component" "0.5.6"
-    "@firebase/firestore" "3.0.0"
+    "@firebase/firestore" "3.0.1"
     "@firebase/firestore-types" "2.5.0"
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
@@ -1131,10 +1131,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-2.5.0.tgz#16fca40b6980fdb000de86042d7a96635f2bcdd7"
   integrity sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==
 
-"@firebase/firestore@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-3.0.0.tgz#f7b8cc3d8d28b85a901fd66df13f4d61dcc33190"
-  integrity sha512-rbs5EbU/01f7NKHDtedBowpBlqnkVnQlpIuSX5wwGMiPgH8f9pMhh59JMk0cTaSqsJXsq3KvafWAD9SqWIqe2w==
+"@firebase/firestore@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-3.0.1.tgz#0152c6a767e116382fb28a0e62b6ea7fa331cc20"
+  integrity sha512-HDnmweq9GOrk4AtCyQ50FBj/cRowb7IXeTGOx6/MSGYCodKv+9axviKqKPYlWH7cbyrw2Jf3GJTUdkVghMhn+w==
   dependencies:
     "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
@@ -1145,10 +1145,10 @@
     node-fetch "2.6.1"
     tslib "^2.1.0"
 
-"@firebase/functions-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.1.0.tgz#53e2b3b9590b04628e9537806196d91deb3e6f3f"
-  integrity sha512-uNwHdGYqgIXzF7aTZBeUe00K/sadRg5EeSDuJ6VNo3Gh3ZceX4eRnL5p7l2bEJBh8hBl0brb82+TRYjGHtjtFQ==
+"@firebase/functions-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.1.1.tgz#b1afb89750ec4d1b9a1a9a188f20c30b75aa4a93"
+  integrity sha512-HELDScvKEP/tM6eW52u+5ilqweCB/cB8ONiQ0aHw2Hjdm20DQ/VsII2JEtbhnFQfuODdugvWLkWV0RPWTFwYqA==
   dependencies:
     "@firebase/component" "0.5.6"
     "@firebase/functions" "0.7.0"
@@ -1281,13 +1281,13 @@
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
-"@firebase/storage-compat@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.1.0.tgz#b8080e3250b19ad6d98a5ade65f1a03aab73f2b8"
-  integrity sha512-DJstR2vidnyNSRp14LQhd9QO0PxhMm/xsXrPQ2IEmQ7EWDT4rxGd+pkqXTG6IO+k9ZKMc0BnWIYwlMqkGEJoDg==
+"@firebase/storage-compat@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.1.1.tgz#9192cd26595a2a09ebef1bbd3da1b63f4716da37"
+  integrity sha512-W2ke6KcnrEY1zvlEZ8GOVt8wgUbIhW3ZCBUYMdpsLKB/uFmn/zgdiba+ojwerqlOH5zUe4CSULqBE1hXDm1pMw==
   dependencies:
     "@firebase/component" "0.5.6"
-    "@firebase/storage" "0.8.0"
+    "@firebase/storage" "0.8.1"
     "@firebase/storage-types" "0.6.0"
     "@firebase/util" "1.3.0"
     tslib "^2.1.0"
@@ -1297,10 +1297,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.6.0.tgz#0b1af64a2965af46fca138e5b70700e9b7e6312a"
   integrity sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==
 
-"@firebase/storage@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.8.0.tgz#2766a18a8a9684082d745ab1a93a3c88061169b1"
-  integrity sha512-D0HH+y3DLH0+8eOt6h19RffFMpdzPNr7Yv7XpeeM3+VLE4TbQnDie/OAQWOuWLrYoW7MsPQnLkx+zDb3DxOXxw==
+"@firebase/storage@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.8.1.tgz#38959b5011df90de4041dbe7277093e010169eba"
+  integrity sha512-kq6biRi86JUNU3ZQc7UrUYJ+QmPmayER68sXtHmn8Kxw7p/V5MchTPVpE8iFAN5a5PhGTPKSD4cuNyUPU9C0Fg==
   dependencies:
     "@firebase/component" "0.5.6"
     "@firebase/util" "1.3.0"
@@ -1866,10 +1866,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
+"@types/node@*":
   version "16.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
   integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
+
+"@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "16.7.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
+  integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3173,10 +3178,15 @@ core-js@3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@^2.8.5:
   version "2.8.5"
@@ -4277,25 +4287,25 @@ firebase-tools@^9.10.2:
     ws "^7.2.3"
 
 firebase@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-9.0.0.tgz#00bfa03a3eb99bde43a472a8861aa808068153bb"
-  integrity sha512-atgnuvELhU9D5w9moChnyCb6GRbOCqk54/kHN0J4kdLJBncpcb2culIJ7nlSHILMcW9MNMiNKDJ07RwXVyqFFA==
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-9.0.1.tgz#6bc5f9d7bdcd864ef98f2219fa0cd240f2e48b3c"
+  integrity sha512-RMpbXsVlxqMX+s/gYudnUZeSZXPiLCJMdaxbZ0WRiMjLuJc6ZkbpRy7yz7rZQpL0wRD6gN4K5C+JaKEQtN3jAQ==
   dependencies:
     "@firebase/analytics" "0.7.0"
-    "@firebase/analytics-compat" "0.1.0"
+    "@firebase/analytics-compat" "0.1.1"
     "@firebase/app" "0.7.0"
     "@firebase/app-check" "0.4.0"
-    "@firebase/app-check-compat" "0.1.0"
-    "@firebase/app-compat" "0.1.0"
+    "@firebase/app-check-compat" "0.1.1"
+    "@firebase/app-compat" "0.1.1"
     "@firebase/app-types" "0.7.0"
-    "@firebase/auth" "0.17.0"
-    "@firebase/auth-compat" "0.1.0"
+    "@firebase/auth" "0.17.1"
+    "@firebase/auth-compat" "0.1.1"
     "@firebase/database" "0.12.0"
     "@firebase/database-compat" "0.1.0"
-    "@firebase/firestore" "3.0.0"
-    "@firebase/firestore-compat" "0.1.0"
+    "@firebase/firestore" "3.0.1"
+    "@firebase/firestore-compat" "0.1.1"
     "@firebase/functions" "0.7.0"
-    "@firebase/functions-compat" "0.1.0"
+    "@firebase/functions-compat" "0.1.1"
     "@firebase/installations" "0.5.0"
     "@firebase/messaging" "0.9.0"
     "@firebase/messaging-compat" "0.1.0"
@@ -4304,8 +4314,8 @@ firebase@^9.0.0:
     "@firebase/polyfill" "0.3.36"
     "@firebase/remote-config" "0.2.0"
     "@firebase/remote-config-compat" "0.1.0"
-    "@firebase/storage" "0.8.0"
-    "@firebase/storage-compat" "0.1.0"
+    "@firebase/storage" "0.8.1"
+    "@firebase/storage-compat" "0.1.1"
     "@firebase/util" "1.3.0"
 
 flat-arguments@^1.0.0:
@@ -7952,9 +7962,9 @@ selenium-webdriver@4.0.0-beta.1:
     ws "^7.3.1"
 
 selenium-webdriver@^4.0.0-beta.2:
-  version "4.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.4.tgz#db4fc7505a515ea3b4a95ded031b738a1544eddd"
-  integrity sha512-+s/CIYkWzmnC9WASBxxVj7Lm0dcyl6OaFxwIJaFCT5WCuACiimEEr4lUnOOFP/QlKfkDQ56m+aRczaq2EvJEJg==
+  version "4.0.0-rc-1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-1.tgz#b1e7e5821298c8a071e988518dd6b759f0c41281"
+  integrity sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==
   dependencies:
     jszip "^3.6.0"
     rimraf "^3.0.2"
@@ -9337,14 +9347,19 @@ write-pkg@^4.0.0:
     write-json-file "^3.2.0"
 
 ws@>=7.4.6:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.0.tgz#0b738cd484bfc9303421914b11bb4011e07615bb"
-  integrity sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.1.tgz#bdd92b3c56fdb47d2379b5ae534281922cc5bd12"
+  integrity sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==
 
-ws@^7.2.3, ws@^7.3.1, ws@^7.4.6:
+ws@^7.2.3, ws@^7.4.6:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+
+ws@^7.3.1:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.4.tgz#56bfa20b167427e138a7795de68d134fe92e21f9"
+  integrity sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
If one used Firestore data converters & built classes, these were getting thrown away when using `docData`/`collectionData`. 

```ts
class Foo {
  static fromFirestore(snapshot: QueryDocumentSnapshot) {
     return new Foo(...);
  }
}

const fooCollection = collection(firestore, 'foo').withConverter(Foo);

// NOW:
collectionData(fooCollection) //=> Observable<Foo[]>

// BEFORE:
collectionData(fooCollection) //=> Observable<{ ... }[]>
```

~~For now I've set use with `idField` etc. to throw, as there isn't really a point; since one could consume `snapshot.id` in the converter.~~ In thinking about it I decided to take a less opinionated approach here, a lighter touch for semver for folk using converters now.

Technically speaking this is a break, since if you converter returns a non object it won't be splatted any longer. E.g, `undefined` will return `undefined` rather than `{}` if you use `collectionData`. But I consider this undefined behavior as we don't provide any guides here, WDYT @jhuleatt?

**Follow on:**

* going to dry everything up
* add generic support (without forcing converters)
* flush out the tests a bit more

Misc.:

* Bump versions
* Add tests back into canary/release script
* Addressed some flaky tests
* Yarn.lock was showing in the github diff, mark as generated