### PR TITLE
`httpsCallable` type cleanup

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -24,13 +24,13 @@ import { map } from 'rxjs/operators';
 type Functions = import('firebase/functions').Functions;
 type HttpsCallableOptions = import('firebase/functions').HttpsCallableOptions;
 
-export function httpsCallable<T, R>(
+export function httpsCallable<RequestData = unknown, ResponseData = unknown>(
   functions: Functions,
   name: string,
   options?: HttpsCallableOptions,
-): (data: T) => Observable<R> {
-  const callable = vanillaHttpsCallable(functions, name, options);
-  return (data: T) => {
-    return from(callable(data)).pipe(map(r => r.data as R));
+): (data?: RequestData | null) => Observable<ResponseData> {
+  const callable = vanillaHttpsCallable<RequestData, ResponseData>(functions, name, options);
+  return (data) => {
+    return from(callable(data)).pipe(map(r => r.data));
   };
 }


### PR DESCRIPTION
Update RxFire's `httpsCallable` to align with the JS SDK's `httpsCallable`.

- [x] Update generics names to match the JS SDK's [`httpsCallable`](https://github.com/firebase/firebase-js-sdk/blob/21866c268524d2509e849e16f670fa949951ebf5/packages/functions/src/api.ts#L82) (`RequestData` and `ResponseData`)
- [x] Default `RequestData` and `ResponseData` to unknown, just like the JS SDK's [`httpsCallable`](https://github.com/firebase/firebase-js-sdk/blob/21866c268524d2509e849e16f670fa949951ebf5/packages/functions/src/api.ts#L82)
- [x] Make `data` optional so it matches [`HttpsCallable`](https://github.com/firebase/firebase-js-sdk/blob/21866c268524d2509e849e16f670fa949951ebf5/packages/functions/src/public-types.ts#L36-L38)
- [x] Pass generics through to `vanillaHttpsCallable` so we don't need to `as` the result