### PR TITLE
point package.json browser field to esm build

### DIFF
--- a/remote-config/package.json
+++ b/remote-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rxfire/remote-config",
-    "browser": "../dist/rxfire-remote-config.js",
+    "browser": "../dist/remote-config/index.esm.js",
     "main": "../dist/remote-config/index.cjs.js",
     "module": "../dist/remote-config/index.esm.js",
     "typings": "../dist/remote-config/index.d.ts",


### PR DESCRIPTION
  bundlers get caught up in the missing file, see #13 for referrence