### PR TITLE
Declare package exports in the actual package instead of the parent.

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/auth/index.cjs.js",
   "module": "../dist/auth/index.esm.js",
   "typings": "../dist/auth/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/database/package.json
+++ b/database/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/database/index.cjs.js",
   "module": "../dist/database/index.esm.js",
   "typings": "../dist/database/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/firestore/lite/package.json
+++ b/firestore/lite/package.json
@@ -4,5 +4,10 @@
   "main": "../../dist/firestore/lite/index.cjs.js",
   "module": "../../dist/firestore/lite/index.esm.js",
   "typings": "../../dist/firestore/lite/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/firestore/package.json
+++ b/firestore/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/firestore/index.cjs.js",
   "module": "../dist/firestore/index.esm.js",
   "typings": "../dist/firestore/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/functions/index.cjs.js",
   "module": "../dist/functions/index.esm.js",
   "typings": "../dist/functions/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,38 +14,6 @@
     ".": {
       "import": "./dist/index.esm.js",
       "require": "./dist/index.cjs.js"
-    },
-    "./auth": {
-      "import": "./dist/auth/index.esm.js",
-      "require": "./dist/auth/index.cjs.js"
-    },
-    "./database": {
-      "import": "./dist/database/index.esm.js",
-      "require": "./dist/database/index.cjs.js"
-    },
-    "./firestore": {
-      "import": "./dist/firestore/index.esm.js",
-      "require": "./dist/firestore/index.cjs.js"
-    },
-    "./firestore/lite": {
-      "import": "./dist/firestore/lite/index.esm.js",
-      "require": "./dist/firestore/lite/index.cjs.js"
-    },
-    "./functions": {
-      "import": "./dist/functions/index.esm.js",
-      "require": "./dist/functions/index.cjs.js"
-    },
-    "./performance": {
-      "import": "./dist/performance/index.esm.js",
-      "require": "./dist/performance/index.cjs.js"
-    },
-    "./remote-config": {
-      "import": "./dist/remote-config/index.esm.js",
-      "require": "./dist/remote-config/index.cjs.js"
-    },
-    "./storage": {
-      "import": "./dist/storage/index.esm.js",
-      "require": "./dist/storage/index.cjs.js"
     }
   },
   "sideEffects": false,

--- a/performance/package.json
+++ b/performance/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/performance/index.cjs.js",
   "module": "../dist/performance/index.esm.js",
   "typings": "../dist/performance/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }

--- a/remote-config/package.json
+++ b/remote-config/package.json
@@ -4,6 +4,11 @@
     "main": "../dist/remote-config/index.cjs.js",
     "module": "../dist/remote-config/index.esm.js",
     "typings": "../dist/remote-config/index.d.ts",
-    "sideEffects": false
-  }
+    "sideEffects": false,
+    "type": "module",
+    "exports": {
+        "import": "./index.esm.js",
+        "require": "./index.cjs.js"
+    }
+}
   

--- a/storage/package.json
+++ b/storage/package.json
@@ -4,5 +4,10 @@
   "main": "../dist/storage/index.cjs.js",
   "module": "../dist/storage/index.esm.js",
   "typings": "../dist/storage/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    "import": "./index.esm.js",
+    "require": "./index.cjs.js"
+  }
 }


### PR DESCRIPTION
Hey,

I am not using the library or have good knowledge on the exports topic but on taking a closer look it seemed like the exports as shown in the PR make more sense.
I [made a SvelteKit repo](https://github.com/konstantinblaesi/issue-repros-rxfire-auth-import) that can demonstrate the runtime issue due to bad exports . I only used npm link to confirm that those changes resolved my error.
Do these make sense or would it break something else?

Fixes #52