### PR TITLE
feat(firestore): Add SnapshotOptions

### DIFF
--- a/firestore/collection/index.ts
+++ b/firestore/collection/index.ts
@@ -34,7 +34,7 @@ import {
 } from 'rxjs/operators';
 import {snapToData} from '../document';
 import {DocumentChangeType, DocumentChange, Query, QueryDocumentSnapshot, QuerySnapshot, DocumentData} from '../interfaces';
-import {getCountFromServer, refEqual} from 'firebase/firestore';
+import {SnapshotOptions, getCountFromServer, refEqual} from 'firebase/firestore';
 import {CountSnapshot} from '../lite/interfaces';
 const ALL_EVENTS: DocumentChangeType[] = ['added', 'modified', 'removed'];
 
@@ -289,7 +289,7 @@ export function collectionData<T=DocumentData, U extends string=never>(
     query: Query<T>,
     options: {
   idField?: ((U | keyof T) & keyof NonNullable<T>),
-}={},
+  } & SnapshotOptions={},
 ): Observable<((T & { [T in U]: string; }) | NonNullable<T>)[]> {
   return collection(query).pipe(
       map((arr) => {

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -20,7 +20,7 @@ import {DocumentReference, DocumentSnapshot, DocumentData} from '../interfaces';
 import {fromRef} from '../fromRef';
 import {map} from 'rxjs/operators';
 import {Observable} from 'rxjs';
-import { SnapshotOptions } from 'firebase/firestore';
+import {SnapshotOptions} from 'firebase/firestore';
 
 export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<DocumentSnapshot<T>> {
   return fromRef(ref, {includeMetadataChanges: true});

--- a/firestore/document/index.ts
+++ b/firestore/document/index.ts
@@ -20,6 +20,7 @@ import {DocumentReference, DocumentSnapshot, DocumentData} from '../interfaces';
 import {fromRef} from '../fromRef';
 import {map} from 'rxjs/operators';
 import {Observable} from 'rxjs';
+import { SnapshotOptions } from 'firebase/firestore';
 
 export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<DocumentSnapshot<T>> {
   return fromRef(ref, {includeMetadataChanges: true});
@@ -33,8 +34,8 @@ export function doc<T=DocumentData>(ref: DocumentReference<T>): Observable<Docum
 export function docData<T=DocumentData, R extends T=T>(
     ref: DocumentReference<T>,
     options: {
-      idField?: keyof R
-    }={},
+      idField?: keyof R,
+    } & SnapshotOptions ={},
 ): Observable<T | R | undefined> {
   return doc(ref).pipe(map((snap) => snapToData(snap, options)));
 }
@@ -43,9 +44,9 @@ export function snapToData<T=DocumentData, R extends T=T>(
     snapshot: DocumentSnapshot<T>,
     options: {
       idField?: keyof R,
-    }={},
+    } & SnapshotOptions ={},
 ): T | R | undefined {
-  const data = snapshot.data();
+  const data = snapshot.data(options);
 
   // match the behavior of the JS SDK when the snapshot doesn't exist
   // it's possible with data converters too that the user didn't return an object

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -35,7 +35,7 @@ import {
 } from '../dist/firestore';
 import {map, take, skip} from 'rxjs/operators';
 import {default as TEST_PROJECT, firestoreEmulatorPort} from './config';
-import {getDocs, collection as firestoreCollection, getDoc, DocumentReference, doc as firestoreDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, updateDoc, connectFirestoreEmulator, doc, setDoc, DocumentChange, collection as baseCollection, QueryDocumentSnapshot, addDoc, SnapshotOptions} from 'firebase/firestore';
+import {getDocs, collection as firestoreCollection, getDoc, DocumentReference, doc as firestoreDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, updateDoc, connectFirestoreEmulator, doc, setDoc, DocumentChange, collection as baseCollection, QueryDocumentSnapshot, addDoc} from 'firebase/firestore';
 import {initializeApp, deleteApp, FirebaseApp} from 'firebase/app';
 
 const createId = (): string => Math.random().toString(36).substring(5);
@@ -386,7 +386,7 @@ describe('RxFire Firestore', () => {
 
     it('docData should be able to provide SnapshotOptions', (done: jest.DoneCallback) => {
       const {davidDoc} = seedTest(firestore);
-      const unwrapped = docData(davidDoc, { serverTimestamps: "estimate", idField: 'UID' });
+      const unwrapped = docData(davidDoc, {serverTimestamps: 'estimate', idField: 'UID'});
 
       unwrapped.subscribe((val) => {
         const expectedDoc = {

--- a/test/firestore.test.ts
+++ b/test/firestore.test.ts
@@ -35,7 +35,7 @@ import {
 } from '../dist/firestore';
 import {map, take, skip} from 'rxjs/operators';
 import {default as TEST_PROJECT, firestoreEmulatorPort} from './config';
-import {getDocs, collection as firestoreCollection, getDoc, DocumentReference, doc as firestoreDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, updateDoc, connectFirestoreEmulator, doc, setDoc, DocumentChange, collection as baseCollection, QueryDocumentSnapshot, addDoc} from 'firebase/firestore';
+import {getDocs, collection as firestoreCollection, getDoc, DocumentReference, doc as firestoreDoc, Firestore as FirebaseFirestore, CollectionReference, getFirestore, updateDoc, connectFirestoreEmulator, doc, setDoc, DocumentChange, collection as baseCollection, QueryDocumentSnapshot, addDoc, SnapshotOptions} from 'firebase/firestore';
 import {initializeApp, deleteApp, FirebaseApp} from 'firebase/app';
 
 const createId = (): string => Math.random().toString(36).substring(5);
@@ -355,7 +355,7 @@ describe('RxFire Firestore', () => {
       const {colRef} = seedTest(firestore);
 
       // const unwrapped = collection(colRef).pipe(unwrap('userId'));
-      const unwrapped = collectionData(colRef, {idField: 'userId'});
+      const unwrapped = collectionData(colRef, {idField: 'userId', serverTimestamps: 'estimate'});
 
       unwrapped.subscribe((val) => {
         const expectedDoc = {
@@ -373,6 +373,20 @@ describe('RxFire Firestore', () => {
 
       // const unwrapped = doc(davidDoc).pipe(unwrap('UID'));
       const unwrapped = docData(davidDoc, {idField: 'UID'});
+
+      unwrapped.subscribe((val) => {
+        const expectedDoc = {
+          name: 'David',
+          UID: 'david',
+        };
+        expect(val).toEqual(expectedDoc);
+        done();
+      });
+    });
+
+    it('docData should be able to provide SnapshotOptions', (done: jest.DoneCallback) => {
+      const {davidDoc} = seedTest(firestore);
+      const unwrapped = docData(davidDoc, { serverTimestamps: "estimate", idField: 'UID' });
 
       unwrapped.subscribe((val) => {
         const expectedDoc = {


### PR DESCRIPTION
Mostly addresses #58.

This PR adds support for `SnapshotOptions` within the data mapping functions like `docData()` and `collectionData()`. The existing options object only supported `idField`. This PR merges that configuration with `SnapshotOptions` to avoid a breaking change. We will address the addition of `SnapshotOptions` for non data mapping functions in the next release as it would require an awkward API or a breaking change.

```ts
collectionData(colRef, {idField: 'userId', serverTimestamps: 'estimate'});
docData(docRef, {idField: 'userId', serverTimestamps: 'estimate'});
```