### PR TITLE
fix(version): accept firebase 12 in peer range

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         node: ["20"]
-        firebase: ["9", "10", "11"]
+        firebase: ["9", "10", "11", "12"]
         rxjs: ["6", "7"]
       fail-fast: false
     name: Test firebase@${{ matrix.firebase }} rxjs@${{ matrix.rxjs }} on Node.js ${{ matrix.node }}

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jest": "jest --detectOpenHandles"
   },
   "peerDependencies": {
-    "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
     "rxjs": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
rxfire's `firebase` peer range stops at `^11`, so installing it alongside firebase 12 resolves two copies of the SDK. Downstream, `@angular/fire@21.0.0-rc.0` pairs `firebase ^12.4.0` with `rxfire ^6.1.0`, and the first Firestore read then crashes with `FirebaseError: Type does not match the expected instance`. This blocks AngularFire 21 from reaching a stable release.

This widens the peer range to also accept firebase 12 and adds a firebase 12 cell to the CI test matrix. It is the third recurrence of the same lag, after v10 (#76) and v11 (#117), and follows the identical minimal shape.

### What changed

- `package.json`: `"firebase": "^9.0.0 || ^10.0.0 || ^11.0.0"` becomes `"^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"`.
- `.github/workflows/test.yml`: the test matrix `firebase` list gains `"12"`.

### Why this is safe

- The widening is additive: firebase 9 through 11 stay supported, so it is a non-breaking change suitable for a 6.x release.
- rxfire's source imports only stable modular v9+ APIs, with no removed or renamed symbols in v12.
- `yarn build` (tsc plus rollup) is clean against firebase 12, and the full emulator test suite (auth, firestore, firestore-lite, database, functions) passes with firebase 12 installed.

### Coverage note for reviewers

The new matrix cell exercises firebase 12 at runtime, but not at type-check time. CI compiles the published bundle once in the `build` job against the `firebase` devDependency (currently `^10`), and every test cell reuses that one bundle; the test run itself strips types without checking them.

So the firebase 12 cell verifies runtime behavior, and the type-level check against firebase 12 was done locally for this change (`yarn build` against firebase 12.16.0). This matches the coverage the existing firebase 9 and 11 cells already have; closing the gap for every supported major (for example, a type-check step per matrix version, or moving the devDependency forward) is a separate CI improvement, out of scope here to keep this change minimal.

This is deliberately scoped to the peer range only, as a small alternative to the broader changes in #123.

Fixes #122
