### PR TITLE
ci: install JDK 21 so firebase-tools emulators can run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
+      - name: Setup Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: node_modules cache
         id: node_modules_cache
         uses: actions/cache@v4


### PR DESCRIPTION
The `test` job (the workflow job that runs the emulator matrix) runs the Firebase emulators via `npx firebase-tools@latest`, which now requires a JDK at version 21 or above. The workflow has no Java setup step, so the runner's default JDK is used and every emulator run fails at startup with:

```
Error: firebase-tools no longer supports Java version before 21. Please install a JDK at version 21 or above to get a compatible runtime.
```

This has left the whole test matrix red regardless of the firebase or rxjs version under test.

This adds an `actions/setup-java` step (Temurin 21, pinned to the v5.6.0 commit SHA) to the `test` job so the emulators start. Only the `test` job needs it; the `build` and `lint` jobs do not run the emulators.

The action is pinned to a commit SHA rather than a floating tag because a SHA is the only immutable reference, following [GitHub's security-hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) for third-party actions.
